### PR TITLE
解决MacOS+Chrome环境下粘贴图片上传功能失效的问题&解决部分环境下浏览器内复制图片粘贴上传失效的问题

### DIFF
--- a/assets/Config/editormd.js
+++ b/assets/Config/editormd.js
@@ -157,8 +157,16 @@
                 if (itemLength === 1 && cbd.items[0].kind === 'string') {
                     return;
                 }
-                if ((itemLength === 1 && cbd.items[0].kind === 'file')) {
-                    var item = cbd.items[0];
+
+                // 此处itemLength等于2的情况是为了兼容MacOS，其剪贴板内包含两个元素，一个是文件名，一个是文件二进制数据
+                if ((itemLength === 1 && cbd.items[0].kind === 'file') || itemLength === 2 && cbd.items[1].kind === 'file') {        
+                    if (itemLength === 1) {
+                        var item = cbd.items[0];
+                    } else {
+                        var item = cbd.items[1];
+                    }
+
+                    
                     var blob = item.getAsFile();
                     if (blob.size === 0) {
                         return;


### PR DESCRIPTION
MacOS+Chrome环境下无法实现粘贴图片自动上传，且无法通过在浏览器内复制图片-粘贴图片的方式实现自动上传，经过分析发现`clipboardData`包含了两个`item`，第一个是`string`，第二个才是`file`，因此针对这种情况做一个例外。

P.S. 目前Clipboard相关API非常混乱，经过测试，得出以下兼容性表格：
1. 通过文件资源管理器复制图片，粘贴到编辑器内：

浏览器/操作系统 | MacOS | Windows
-- | -- | --
Chrome/Chromium | 不支持（已经修复，但依然会附带文件名） | 不支持（没有任何反应）
Firefox | 不支持（只粘贴文件名） | 不支持（没有任何反应）
Safari | 支持（附带了文件名） | /
IE | / | 不支持（没有任何反应）

2. 通过浏览器中的『复制图片』功能复制图片，粘贴到编辑器内：

| 浏览器/操作系统 | MacOS                              | Windows                                                      |
| --------------- | ---------------------------------- | ------------------------------------------------------------ |
| Chrome/Chromium | 不支持（已经修复，不会附带文件名） | 不支持（已经修复，不会附带文件名）                        |
| Firefox         | 不支持（已经修复，不会附带文件名） | 不支持（已经修复，不会附带文件名）                           |
| Safari          | 不支持（已经修复，不会附带文件名） | /                                                            |
| IE              | /                                  | 不支持（只会复制到形如`file:///C:/Users/LuRenJia/Desktop/IMG_1112.JPG`）的本地路径 |




> 因为Linux发行版众多，无法一一测试，此处略过，但就我使用的KDE+Arch Linux来看，完全不支持该功能。

我尝试了一些常用的Hack Method / Library，发现其在不同平台下的兼容性依旧存在问题，以[paste.js](http://layerssss.github.io/paste.js/)为例，基本上只有启用`contenteditable`的`div`才能得到较好的兼容性（同样存在行为不一致、不兼容的情况）。

我继续研究了腾讯文档、石墨文档、Google Docs与Office Online对该功能的实现，发现同样存在大量兼容性问题。比如腾讯文档，在Windows平台的Firefox下可以完美实现图片粘贴，但在Windows平台的Chrome、Edge与IE下则完全无效，其他几款在线文档情况类似。

目前浏览器的剪贴板API经历了一改再改的过程，依旧未能定型，同时存在`Clipboard`、`execCommand`与`Onpaste Event`三种方式，以及其他各浏览器自己的实现……因此实在没有一劳永逸的办法可以解决该问题，只能尽可能的在各个平台与各个浏览器的排列组合下一个一个解决，最后再抽象成一个单独用来解决剪贴板问题的库（尽管如此，部分操作系统+浏览器的组合限制于操作系统的权限与浏览器的实现，依旧无法搞定）。

总而言之，目前我先把MacOS+Chrome下面的情况解决了，下一步可能是解决Windows+Chrome（前提是确定有相关的API），毕竟Chrome是大部分用户的选择。如果Edge能尽快更新到Chromium内核，那Edge也可以顺带解决。

目前我能做的只有这些，后续可能会考虑增加一个兼容性列表的功能，如果用户在兼容性列表以外，考虑予以提示。期待能早日看到统一后的Clipboard API，这样的话该功能会更加易于开发和易于使用。

![QQ20191121-235942](https://user-images.githubusercontent.com/29622423/69354400-045f6600-0cbb-11ea-8e07-9759ab718398.png)
