### PR TITLE
fix issue [Class 'EditormdApp\IXR_Message' not found in ***/wp-conten…

### DIFF
--- a/src/App/WPComMarkdown.php
+++ b/src/App/WPComMarkdown.php
@@ -717,7 +717,7 @@ class WPComMarkdown {
             return;
         }
         include_once(ABSPATH . WPINC . "/class-IXR.php");
-        $message = new IXR_Message($raw_post_data);
+        $message = new \IXR_Message($raw_post_data);
         $message->parse();
         $post_id_position = "metaWeblog.getPost" === $message->methodName ? 0 : 1;
         $this->prime_post_cache($message->params[$post_id_position]);


### PR DESCRIPTION
I'm new to PHP and this is probably a namespace problem.


error：

[12-Nov-2021 09:17:45 UTC] PHP Fatal error:  Uncaught Error: Class 'EditormdApp\IXR_Message' not found in /var/www/html/wp-content/plugins/wp-editormd/src/App/WPComMarkdown.php:723
Stack trace:
#0 /var/www/html/wp-content/plugins/wp-editormd/src/App/WPComMarkdown.php(100): EditormdApp\WPComMarkdown->check_for_early_methods()
#1 /var/www/html/wp-content/plugins/wp-editormd/src/App/WPComMarkdown.php(72): EditormdApp\WPComMarkdown->load_markdown_for_posts()
#2 /var/www/html/wp-content/plugins/wp-editormd/src/App/WPComMarkdown.php(34): EditormdApp\WPComMarkdown->maybe_load_actions_and_filters()
#3 /var/www/html/wp-includes/class-wp-hook.php(303): EditormdApp\WPComMarkdown->load('')
#4 /var/www/html/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
#5 /var/www/html/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#6 /var/www/html/wp-settings.php(578): do_action('init')
#7 /var/www/html/wp-config.php(140): require_once('/var/www/html/w...')
#8 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...')
#9 /var/www/html/xmlrpc in /var/www/html/wp-content/plugins/wp-editormd/src/App/WPComMarkdown.php on line 723

