### PR TITLE
重构了标识符匹配函数；增加匹配符内部空格判断，防止正文内容被误渲染。

### DIFF
--- a/src/App/KaTeX.php
+++ b/src/App/KaTeX.php
@@ -2,7 +2,8 @@
 /**
  * KaTeX support.
  *
- * Backward compatibility requires support for both "$$katex$$" shortcodes.
+ * 重构公式标识符函数，统一了单美元符号和双美元符号的处理流程，
+ * 修复了执行顺序问题，并提升了正则表达式的稳定性。
  *
  */
 
@@ -12,249 +13,146 @@ use EditormdUtils\Config;
 class KaTeX {
 
     public function __construct() {
-
-        //单个$或者双个$$符号匹配
-        add_filter("the_content", array($this, "katex_markup_single"), 9);
-        add_filter("comment_text", array($this, "katex_markup_single"), 9);
-
-        add_filter("the_content", array($this, "katex_markup_double"), 8);
-        add_filter("comment_text", array($this, "katex_markup_double"), 8);
-        //前端加载资源
+        // 使用统一的处理函数，并设置合理的优先级
+        add_filter("the_content", array($this, "katex_markup"), 9);
+        add_filter("comment_text", array($this, "katex_markup"), 9);
+        
+        // 前端加载资源
         add_action("wp_enqueue_scripts", array($this, "katex_enqueue_scripts"));
 
         if (! in_array($GLOBALS["pagenow"], array("wp-login.php", "wp-register.php"))) {
-            //执行公式渲染操作
+            // 执行公式渲染操作
             add_action("wp_print_footer_scripts", array($this, "katex_wp_footer_scripts"));
         }
-
     }
-
-    public function katex_markup_single($content) {
-        // 匹配单行LaTeX
-        $regexTeXInline = '
-        %
-        \$
-            ((?:
-                [^$]+ # Not a dollar
-                |
-                (?<=(?<!\\\\)\\\\)\$ # Dollar preceded by exactly one slash
-                )+)
-            (?<!\\\\)
-        \$ # Dollar preceded by zero slashes
-        %ix';
-
-        // 简易版本，可能存在误判，但尽可能简单，以避免上面这个LaTeX引起的性能问题
-        $regexTeXMultilineLite = "/\$[\S\ ]+?\$/ix";
-        
-        $content = preg_replace_callback($regexTeXMultilineLite, array($this, "katex_src_replace"), $content);
+    
+    /**
+     * 用于处理行内 ($...$) 和行外 ($$...$$) KaTeX 标记的统一函数。
+     * 这样可以避免两个独立函数之间产生的冲突和顺序问题。
+     */
+    public function katex_markup($content) {
+        /**
+         * 一个用于捕获行外和行内数学公式的统一正则表达式。
+         * 使用 OR '|' 操作符，并优先尝试匹配更长的 '$$' 标识符。
+         * 这可以防止 '$$' 被错误地解析为两个独立的 '$' 。
+         *
+         * 正则表达式分解:
+         * 捕获组 1: 匹配整个 $$...$$ 块。
+         *  ->捕获组 2: 捕获 $$...$$ 内部的实际 LaTeX 内容。
+         * 捕获组 3: 匹配整个 $...$ 块。
+         *  ->捕获组 4: 捕获 $...$ 内部的实际 LaTeX 内容。
+         */
+        $regex = '/
+            (                                      # 捕获组 1: 捕获 $$...$$ 块
+                \$\$                               # 以 $$ 开始
+                (                                  # 捕获组 2: 捕获内容
+                    (?:
+                        [^$]+                        # 匹配任何非美元符号的字符
+                        |                          # 或
+                        \$ (?<! \$\$ )               # 匹配一个美元符号，前提是它前面不是另一个美元符号
+                    )+?                            # 一次或多次非贪婪匹配
+                )
+                \$\$                               # 以 $$ 结束
+            )
+            |                                      # 或
+            (                                      # 捕获组 3: 捕获 $...$ 块
+                \$                                 # 以 $ 开始
+                (                                  # 捕获组 4: 捕获内容
+                    (?:
+                        [^$]+                        # 匹配任何非美元符号的字符
+                        |                          # 或
+                        \$ (?<! \$\$ )               # 匹配一个美元符号，前提是它前面不是另一个美元符号
+                    )+?                            # 一次或多次非贪婪匹配
+                )
+                \$                                 # 以 $ 结束
+            )
+        /ix';
 
         $textarr = wp_html_split($content);
-
-        // 需要跳过的行数
-        $count = 0;
-        // 是否需要跳过LaTeX解析
-        $pass  = false;
-        // 是否在代码块内
-        $isInCodeBlock = false;
+        $pass_tags = ['pre', 'code', 'style', 'script']; // 在这些标签内部不会被解析，跳过处理
+        $is_passing = false;
 
         foreach ($textarr as &$element) {
-            // 默认进行LaTeX解析，如果满足下面的判断条件，则跳过
-            $pass = false;
-
-            // 判断已经跳过的行数
-            if ($count > 0) {
-                ++ $count;
-            }
-
-            /**
-             * 1. 判断是否满足如下规则，如果是则不进行LaTeX解析
-             * <pre>
-             * </pre>
-             */
-            // 判断是否是<pre>然后开始计数，此时为第一行
-            if (htmlspecialchars_decode($element) == "<pre>") {
-                $isInCodeBlock = true;
-                $pass = true;
-            }
-
-            // 如果发现是</pre>标签，则表示代码部分结束，继续处理
-            if (htmlspecialchars_decode($element) == "</pre>") {
-                $isInCodeBlock = false;
-                $pass = false;
-            }
-
-            /**
-             * 2. 对于使用```katex的多行LaTeX，不在里面进行单行LaTeX的重复解析
-             */
-            if (strpos(htmlspecialchars_decode($element), '<div class="katex math') === 0) {
-                $count = 1;
-                $pass = true;
+            
+            // 处理进入和退出跳过区域的逻辑
+            if (strpos($element, '<') === 0 && preg_match('/<(\/)?(' . implode('|', $pass_tags) . ').*?>/i', $element, $tag_match)) {
+                if (isset($tag_match[1]) && $tag_match[1] === '/') {
+                    // 这是一个闭合标签
+                    $is_passing = false;
+                } else {
+                    // 这是一个起始标签
+                    $is_passing = true;
+                }
             }
             
-            if ($count == 3 && htmlspecialchars_decode($element) == "</div>") {
-                $count = 0;
-                $pass = false;
-            }
-
-            /**
-             * 3. 对于其他空行或可能为HTML单行标签的行，直接跳过
-             */
-            if ($element == "" || $element[0] == "<" || stripos($element, "$") === false) {
-                $pass = true;
-            }
-
-            /**
-             * 4. 如果当前还在代码块内，继续跳过
-             */
-            if ($isInCodeBlock) {
-                $pass = true;
-            }
-
-            // 如果存在需要跳过LaTeX解析的情况，在这里跳过
-            if ($pass) {
+            if ($is_passing || strpos($element, '<') === 0) {
                 continue;
-            } else {
-                $element = preg_replace_callback($regexTeXInline, array($this, "katex_src_inline"), $element);
+            }
+
+            $element = preg_replace_callback($regex, array($this, "katex_universal_replace"), $element);
+            
+            // 原始代码处理字符 "_" 和 "em" 之间的替换问题，逻辑保留
+            if ($element !== null) { // 检查 preg_ 错误
+                $element = $this->katex_src_replace_em($element);
             }
         }
 
         return implode("", $textarr);
-    }
-
-    public function katex_src_inline($matches) {
-
-        $katex = $matches[1];
-
-        $katex = $this->katex_entity_decode_editormd($katex);
-
-        return '<span class="katex math inline">' . trim($katex) . '</span>';
-    }
-
-    public function katex_markup_double($content) {
-
-        // 匹配多行LaTeX
-        // 尽管只是多了一个$符号，却会引起指数级的回溯
-        $regexTeXMultiline = '
-        %
-        \$\$
-            ((?:
-                [^$]+ # Not a dollar
-                |
-                (?<=(?<!\\\\)\\\\)\$ # Dollar preceded by exactly one slash
-                )+)
-            (?<!\\\\)
-        \$\$ # Dollar preceded by zero slashes
-        %ix';
-
-        // 简易版本，可能存在误判，但尽可能简单，以避免上面这个LaTeX引起的性能问题
-        $regexTeXMultilineLite = '
-        %
-		\$\$
-			([\S\s]+?)
-		\$\$
-        %ix';
-
-        $content = preg_replace_callback($regexTeXMultilineLite, array($this, "katex_src_replace"), $content);
-
-        $textarr = wp_html_split($content);
-
-        // 需要跳过的行数
-        $count = 0;
-        // 是否需要跳过LaTeX解析
-        $pass  = false;
-        // 是否在代码块内
-        $isInCodeBlock = false;
-
-        foreach ($textarr as &$element) {
-            // 默认进行LaTeX解析，如果满足下面的判断条件，则跳过
-            $pass = false;
-
-            // 判断已经跳过的行数
-            if ($count > 0) {
-                ++ $count;
-            }
-
-            /**
-             * 1. 判断是否满足如下规则，如果是则不进行LaTeX解析
-             * <pre>
-             * </pre>
-             */
-            // 判断是否是<pre>然后开始计数，此时为第一行
-            if (htmlspecialchars_decode($element) == "<pre>") {
-                $isInCodeBlock = true;
-                $pass = true;
-            }
-
-            // 如果发现是</pre>标签，则表示代码部分结束，继续处理
-            if (htmlspecialchars_decode($element) == "</pre>") {
-                $isInCodeBlock = false;
-                $pass = false;
-            }
-
-            /**
-             * 2. 对于其他空行或可能为HTML单行标签的行，直接跳过
-             */
-            if ($element == "" || $element[0] == "<" || !stripos($element, "$$")) {
-                $pass = true;
-            }
-
-            /**
-             * 3. 如果当前还在代码块内，继续跳过
-             */
-            if ($isInCodeBlock) {
-                $pass = true;
-            }
-
-            // 如果存在需要跳过LaTeX解析的情况，在这里跳过
-            if ($pass) {
-                continue;
-            } else {
-                $element = preg_replace_callback($regexTeXMultiline, array($this, "katex_src_multiline"), $element);
-            }
-        }
-
-        return implode("", $textarr);
-    }
-
-    public function katex_src_multiline($matches) {
-
-        $katex = $matches[1];
-
-        $katex = $this->katex_entity_decode_editormd($katex);
-
-        return '<span class="katex math multi-line">' . trim($katex) . '</span>';
-    }
-
-    public function katex_src_replace($matches) {
-
-        //在如果公式含有_则会被Markdown解析，所以现在需要转换过来
-        $content = str_replace(
-            array("<em>", "</em>"),
-            array("_", "_"),
-            $matches[0]
-        );
-
-        return $content;
     }
 
     /**
-     * code 内公式渲染
-     * @param $matches
+     * 用于统一正则表达式的通用回调函数。
+     * 判断找到的是行内匹配还是行外匹配，并进行相应处理。
+     * 
+     * 重点**************
+     * 不允许标识符和公式代码之间存在空格。
+     * *****************
      *
-     * @return string|null
+     * $matches 来自 preg_replace_callback 的匹配数组。
+     * 返回替换后的字符串。
      */
-    public function code_katex_src_replace($matches) {
-        $matches = func_get_arg(0);
-
-        if (! empty($matches[1])) {
-            $katex = $matches[1];
-            $katex = $this->katex_entity_decode_editormd($katex);
-            return '<span class="katex math inline">' . trim($katex) . '</span>';
+    public function katex_universal_replace($matches) {
+        // 如果 matches[1] 被设置，则说明是行外 ($$) 匹配。
+        if (!empty($matches[1])) {
+            $type = 'multi-line';
+            $content = $matches[2]; // 内容在捕获组 2 中
+        } 
+        // 如果 matches[3] 被设置，则说明是行内 ($) 匹配。
+        elseif (!empty($matches[3])) {
+            $type = 'inline';
+            $content = $matches[4]; // 内容在捕获组 4 中
+        } 
+        else {
+            return $matches[0]; // 没有有效匹配，返回原始字符串
         }
 
-        return null;
-    }
+        // 重要：检查标识符和公式代码之间是否存在空格。
+        // 如果存在空格则不进行渲染。
+        if (ctype_space(substr($content, 0, 1)) || ctype_space(substr($content, -1))) {
+            return $matches[0];
+        }
 
+        $katex = $this->katex_entity_decode_editormd($content);
+
+        return '<span class="katex math ' . $type . '">' . trim($katex) . '</span>';
+    }
+    
+    /**
+     * 在如果公式含有_则会被Markdown解析，所以现在需要转换过来
+     */
+    public function katex_src_replace_em($content) {
+        // 如果内容不是字符串（例如，preg_ 出错），则返回空字符串。
+        if (!is_string($content)) {
+            return '';
+        }
+        // 以防带有 '_' 的公式被 Markdown 优先解析。
+        return str_replace(
+            array("<em>", "</em>"),
+            array("_", "_"),
+            $content
+        );
+    }
+    
     /**
      * 渲染转换
      * 
@@ -288,8 +186,7 @@ class KaTeX {
     }
 
     public function katex_enqueue_scripts() {
-
-        //兼容模式 - jQuery
+        // 兼容模式 - jQuery
         if (Config::get_option("jquery_compatible", "editor_advanced") !== "off") {
             wp_enqueue_script("jquery", null, null, array(), false);
         } else {
@@ -299,7 +196,6 @@ class KaTeX {
 
         wp_enqueue_style("Katex", Config::get_option("editor_addres","editor_style") . "/assets/KaTeX/katex.min.css", array(), WP_EDITORMD_VER, "all");
         wp_enqueue_script("Katex", Config::get_option("editor_addres","editor_style") . "/assets/KaTeX/katex.min.js", array(), WP_EDITORMD_VER, true);
-
     }
 
     public function katex_wp_footer_scripts() {


### PR DESCRIPTION
用一个正则表达式匹配行内公式 `$....$` 和行外公式 `$$....$$` ；
增加了判断逻辑：如果标识符 `$....$` 或 `$$....$$` 和其中的 LaTeX 代码之间有空格的话，则跳过渲染。避免正文中形如 `function update( $new_instance, $old_instance )` 这样的函数在正文中被错误渲染。
